### PR TITLE
[WIP] Tell getting new goal from cancel

### DIFF
--- a/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp
@@ -547,28 +547,31 @@ void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onJointTrajectoryAct
 {
   ROS_INFO_STREAM("[" << parent->getInstanceName() << "] @onJointTrajectoryActionPreempt()");
   joint_trajectory_server->setPreempted();
-  if (groupname.length() > 0)
-  { // group
-    // hrpsys < 315.5.0 does not have clearJointAngles, so need to use old API
-    // hrpsys < 315.16.0 have bugs in setJointAnglesSequenceOfGroup https://github.com/fkanehiro/hrpsys-base/pull/1237
-    if (LessThanVersion(parent->hrpsys_version, std::string("315.16.0"))) {
-      ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearOfGroup: " << groupname);
-      parent->m_service0->clearOfGroup(groupname.c_str(), 0.05);
-    } else {
-      ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearJointAnglesOfGroup: " << groupname);
-      parent->m_service0->clearJointAnglesOfGroup(groupname.c_str());
+  if (!joint_trajectory_server->isNewGoalAvailable())
+  {
+    if (groupname.length() > 0)
+    { // group
+      // hrpsys < 315.5.0 does not have clearJointAngles, so need to use old API
+      // hrpsys < 315.16.0 have bugs in setJointAnglesSequenceOfGroup https://github.com/fkanehiro/hrpsys-base/pull/1237
+      if (LessThanVersion(parent->hrpsys_version, std::string("315.16.0"))) {
+        ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearOfGroup: " << groupname);
+        parent->m_service0->clearOfGroup(groupname.c_str(), 0.05);
+      } else {
+        ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearJointAnglesOfGroup: " << groupname);
+        parent->m_service0->clearJointAnglesOfGroup(groupname.c_str());
+      }
     }
-  }
-  else
-  { // fullbody
-    ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearJointAngles ");
-    // hrpsys < 315.5.0 does not have clearJointAngles, so need to use old API
-    if (LessThanVersion(parent->hrpsys_version, std::string("315.5.0"))) {
-      ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clear");
-      parent->m_service0->clear();
-    } else {
-      ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearJointAngles");
-      parent->m_service0->clearJointAngles();
+    else
+    { // fullbody
+      ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearJointAngles ");
+      // hrpsys < 315.5.0 does not have clearJointAngles, so need to use old API
+      if (LessThanVersion(parent->hrpsys_version, std::string("315.5.0"))) {
+        ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clear");
+        parent->m_service0->clear();
+      } else {
+        ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearJointAngles");
+        parent->m_service0->clearJointAngles();
+      }
     }
   }
 }
@@ -579,25 +582,28 @@ void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onFollowJointTraject
   ROS_INFO_STREAM("[" << parent->getInstanceName() << "] @onFollowJointTrajectoryActionPreempt()");
   follow_joint_trajectory_server->setPreempted();
 
-  if (groupname.length() > 0)
-  { // group
-    // hrpsys < 315.16.0 have bugs in setJointAnglesSequenceOfGroup https://github.com/fkanehiro/hrpsys-base/pull/1237
-    if (LessThanVersion(parent->hrpsys_version, std::string("315.16.0"))) {
-      ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearOfGroup: " << groupname);
-      parent->m_service0->clearOfGroup(groupname.c_str(), 0.05);
-    } else {
-      ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearJointAnglesOfGroup: " << groupname);
-      parent->m_service0->clearJointAnglesOfGroup(groupname.c_str());
+  if (!follow_joint_trajectory_server->isNewGoalAvailable())
+  {
+    if (groupname.length() > 0)
+    { // group
+      // hrpsys < 315.16.0 have bugs in setJointAnglesSequenceOfGroup https://github.com/fkanehiro/hrpsys-base/pull/1237
+      if (LessThanVersion(parent->hrpsys_version, std::string("315.16.0"))) {
+        ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearOfGroup: " << groupname);
+        parent->m_service0->clearOfGroup(groupname.c_str(), 0.05);
+      } else {
+        ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearJointAnglesOfGroup: " << groupname);
+        parent->m_service0->clearJointAnglesOfGroup(groupname.c_str());
+      }
     }
-  }
-  else
-  { // fullbody
-    if (LessThanVersion(parent->hrpsys_version, std::string("315.5.0"))) {
-      ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearJointAngles");
-      parent->m_service0->clearJointAngles();
-    } else {
-      ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clear");
-      parent->m_service0->clear();
+    else
+    { // fullbody
+      if (LessThanVersion(parent->hrpsys_version, std::string("315.5.0"))) {
+        ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearJointAngles");
+        parent->m_service0->clearJointAngles();
+      } else {
+        ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clear");
+        parent->m_service0->clear();
+      }
     }
   }
 }

--- a/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp
@@ -548,7 +548,8 @@ void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onJointTrajectoryAct
   ROS_INFO_STREAM("[" << parent->getInstanceName() << "] @onJointTrajectoryActionPreempt()");
   joint_trajectory_server->setPreempted();
   if (!joint_trajectory_server->isNewGoalAvailable())
-  {
+  { // Cancel request comes from client, so motion should be stopped immediately,
+    // while motion should be changed smoothly when new goal comes
     if (groupname.length() > 0)
     { // group
       // hrpsys < 315.5.0 does not have clearJointAngles, so need to use old API
@@ -583,7 +584,8 @@ void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onFollowJointTraject
   follow_joint_trajectory_server->setPreempted();
 
   if (!follow_joint_trajectory_server->isNewGoalAvailable())
-  {
+  { // Cancel request comes from client, so motion should be stopped immediately,
+    // while motion should be changed smoothly when new goal comes
     if (groupname.length() > 0)
     { // group
       // hrpsys < 315.16.0 have bugs in setJointAnglesSequenceOfGroup https://github.com/fkanehiro/hrpsys-base/pull/1237

--- a/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp
@@ -600,11 +600,11 @@ void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onFollowJointTraject
     else
     { // fullbody
       if (LessThanVersion(parent->hrpsys_version, std::string("315.5.0"))) {
-        ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearJointAngles");
-        parent->m_service0->clearJointAngles();
-      } else {
         ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clear");
         parent->m_service0->clear();
+      } else {
+        ROS_INFO_STREAM("[" << parent->getInstanceName() << "] clearJointAngles");
+        parent->m_service0->clearJointAngles();
       }
     }
   }

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -244,6 +244,8 @@ void HrpsysSeqStateROSBridge::onFollowJointTrajectoryActionGoal() {
 void HrpsysSeqStateROSBridge::onJointTrajectoryActionPreempt() {
   joint_trajectory_server.setPreempted();
   if (!joint_trajectory_server.isNewGoalAvailable()) {
+    // Cancel request comes from client, so motion should be stopped immediately,
+    // while motion should be changed smoothly when new goal comes.
     // hrpsys < 315.5.0 does not have clearJointAngles, so need to use old API
     if (LessThanVersion(hrpsys_version, std::string("315.5.0"))) {
       m_service0->clear();
@@ -257,6 +259,8 @@ void HrpsysSeqStateROSBridge::onJointTrajectoryActionPreempt() {
 void HrpsysSeqStateROSBridge::onFollowJointTrajectoryActionPreempt() {
   follow_joint_trajectory_server.setPreempted();
   if (!follow_joint_trajectory_server.isNewGoalAvailable()) {
+    // Cancel request comes from client, so motion should be stopped immediately,
+    // while motion should be changed smoothly when new goal comes.
     // hrpsys < 315.5.0 does not have clearJointAngles, so need to use old API
     if (LessThanVersion(hrpsys_version, std::string("315.5.0"))) {
       m_service0->clear();

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -243,22 +243,26 @@ void HrpsysSeqStateROSBridge::onFollowJointTrajectoryActionGoal() {
 #ifdef USE_PR2_CONTROLLERS_MSGS
 void HrpsysSeqStateROSBridge::onJointTrajectoryActionPreempt() {
   joint_trajectory_server.setPreempted();
-  // hrpsys < 315.5.0 does not have clearJointAngles, so need to use old API
-  if (LessThanVersion(hrpsys_version, std::string("315.5.0"))) {
-    m_service0->clear();
-  } else {
-    m_service0->clearJointAngles();
+  if (!joint_trajectory_server.isNewGoalAvailable()) {
+    // hrpsys < 315.5.0 does not have clearJointAngles, so need to use old API
+    if (LessThanVersion(hrpsys_version, std::string("315.5.0"))) {
+      m_service0->clear();
+    } else {
+      m_service0->clearJointAngles();
+    }
   }
 }
 #endif
 
 void HrpsysSeqStateROSBridge::onFollowJointTrajectoryActionPreempt() {
   follow_joint_trajectory_server.setPreempted();
-  // hrpsys < 315.5.0 does not have clearJointAngles, so need to use old API
-  if (LessThanVersion(hrpsys_version, std::string("315.5.0"))) {
-    m_service0->clear();
-  } else {
-    m_service0->clearJointAngles();
+  if (!follow_joint_trajectory_server.isNewGoalAvailable()) {
+    // hrpsys < 315.5.0 does not have clearJointAngles, so need to use old API
+    if (LessThanVersion(hrpsys_version, std::string("315.5.0"))) {
+      m_service0->clear();
+    } else {
+      m_service0->clearJointAngles();
+    }
   }
 }
 


### PR DESCRIPTION
~~Not tested in real robot yet.~~
Not tested in real robot yet.

This PR solves the issue written in https://github.com/start-jsk/rtmros_common/pull/765#issuecomment-392741195 (this issue is specific to HIRONX as https://github.com/start-jsk/rtmros_common/pull/765#issuecomment-546311338).
With this PR, `clearOfGroup` or `clearJointAnglesOfGroup` is not called when new goal comes, while that is called when `cancel` topic comes.
Though this PR is not necessary for robots with new hrpsys (e.g., HRP2JSKNTS), this PR makes https://github.com/start-jsk/rtmros_common/pull/765 more similar behavior to current master branch (difference appears only when `cancel` topic comes).
I think this is more acceptable.