### PR TITLE
apply 2to3 for running hrpsys_simulator with hrpsy_ros_bridge

### DIFF
--- a/hrpsys_ros_bridge/test/sample4legrobot_hrpsys_config.py
+++ b/hrpsys_ros_bridge/test/sample4legrobot_hrpsys_config.py
@@ -54,7 +54,7 @@ class Sample4LegRobotHrpsysConfigurator(HrpsysConfigurator):
                          OpenHRP.StabilizerService.TwoDimensionVertex(pos=[-1*stp_org.eefm_leg_rear_margin, stp_org.eefm_leg_outside_margin])]
         rarm_vertices = rleg_vertices
         larm_vertices = lleg_vertices
-        stp_org.eefm_support_polygon_vertices_sequence = map (lambda x : OpenHRP.StabilizerService.SupportPolygonVertices(vertices=x), [lleg_vertices, rleg_vertices, larm_vertices, rarm_vertices])
+        stp_org.eefm_support_polygon_vertices_sequence = [OpenHRP.StabilizerService.SupportPolygonVertices(vertices=x) for x in [lleg_vertices, rleg_vertices, larm_vertices, rarm_vertices]]
         stp_org.eefm_k1=[-1.39899,-1.39899]
         stp_org.eefm_k2=[-0.386111,-0.386111]
         stp_org.eefm_k3=[-0.175068,-0.175068]

--- a/hrpsys_ros_bridge/test/samplerobot_hrpsys_config.py
+++ b/hrpsys_ros_bridge/test/samplerobot_hrpsys_config.py
@@ -48,7 +48,7 @@ class SampleRobotHrpsysConfigurator(HrpsysConfigurator):
                          OpenHRP.StabilizerService.TwoDimensionVertex(pos=[-1*tmp_leg_rear_margin, tmp_leg_outside_margin])]
         rarm_vertices = rleg_vertices
         larm_vertices = lleg_vertices
-        stp.eefm_support_polygon_vertices_sequence = map (lambda x : OpenHRP.StabilizerService.SupportPolygonVertices(vertices=x), [lleg_vertices, rleg_vertices, larm_vertices, rarm_vertices])
+        stp.eefm_support_polygon_vertices_sequence = [OpenHRP.StabilizerService.SupportPolygonVertices(vertices=x) for x in [lleg_vertices, rleg_vertices, larm_vertices, rarm_vertices]]
         stp.eefm_leg_inside_margin=tmp_leg_inside_margin
         stp.eefm_leg_outside_margin=tmp_leg_outside_margin
         stp.eefm_leg_front_margin=tmp_leg_front_margin

--- a/hrpsys_ros_bridge/test/test-samplerobot.py
+++ b/hrpsys_ros_bridge/test/test-samplerobot.py
@@ -191,7 +191,7 @@ class TestSampleRobot(unittest.TestCase):
 
         ## wait for joint_states updates
         rospy.sleep(1)
-        current_positions = dict(zip(self.joint_states.name, self.joint_states.position))
+        current_positions = dict(list(zip(self.joint_states.name, self.joint_states.position)))
 
         # goal
         goal.trajectory.header.stamp = rospy.get_rostime()
@@ -221,7 +221,7 @@ class TestSampleRobot(unittest.TestCase):
 
         ## wait for joint_states updates
         rospy.sleep(1)
-        current_positions = dict(zip(self.joint_states.name, self.joint_states.position))
+        current_positions = dict(list(zip(self.joint_states.name, self.joint_states.position)))
 
         goal.trajectory.points = []
         ## add current position
@@ -242,7 +242,7 @@ class TestSampleRobot(unittest.TestCase):
 
         ## wait for update joint_states
         rospy.sleep(1)
-        current_positions = dict(zip(self.joint_states.name, self.joint_states.position))
+        current_positions = dict(list(zip(self.joint_states.name, self.joint_states.position)))
         goal_angles = [ 180.0 / math.pi * current_positions[x] for x in goal.trajectory.joint_names]
         rospy.logwarn(goal_angles)
         rospy.logwarn("difference between two angles %r %r"%(array([30,30,30,-90,-40,-30])-array(goal_angles),linalg.norm(array([30,30,30,-90,-40,-30])-array(goal_angles))))


### PR DESCRIPTION
To run `rtmlaunch hrpsys_ros_bridge samplerobot.launch USE_UNSTABLE_RTC:=true`, this pull req and https://github.com/k-okada/hrpsys-base/pull/4 are needed.