### PR TITLE
python2 python3 compatible

### DIFF
--- a/openrtm_tools/scripts/rtmlaunch.py
+++ b/openrtm_tools/scripts/rtmlaunch.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 from openrtm_tools import rtmlaunchlib
 

--- a/openrtm_tools/src/openrtm_tools/rtmlaunchlib.py
+++ b/openrtm_tools/src/openrtm_tools/rtmlaunchlib.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import roslib
 roslib.load_manifest('openrtm_tools')


### PR DESCRIPTION
- python2 python3 compatible for print function
  - successed to run `rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch` in both melodic and noetic