### PR TITLE
[hrpsys_ros_bridge] Enable to compile on pure Ubuntu Focal

### DIFF
--- a/hrpsys_ros_bridge/cmake/compile_robot_model.cmake
+++ b/hrpsys_ros_bridge/cmake/compile_robot_model.cmake
@@ -148,8 +148,13 @@ macro(compile_openhrp_model wrlfile)
 
   if(_controller_config)
     # output controller config (yaml -> config) if yaml is not found write dummy files
+    find_package(PythonInterp QUIET)
+    if(NOT PYTHONINTERP_FOUND)
+      find_package(Python REQUIRED)
+      set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+    endif()  # enable to execute with correct python version (cf. https://github.com/tork-a/openrtm_aist_python-release/pull/5)
     add_custom_command(OUTPUT ${_controller_config}
-      COMMAND ${_controller_config_converter} ${_yamlfile} ${_controller_config}
+      COMMAND ${PYTHON_EXECUTABLE} ${_controller_config_converter} ${_yamlfile} ${_controller_config}
       DEPENDS ${_yamlfile})
     add_custom_target(${_sname}_${PROJECT_NAME}_compile_conf DEPENDS ${_controller_config})
     list(APPEND ${_sname}_${PROJECT_NAME}_compile_all_target ${_sname}_${PROJECT_NAME}_compile_conf)


### PR DESCRIPTION
Currently, building https://github.com/start-jsk/rtmros_common/pull/1134 on pure Ubuntu Focal fails due to the following error:
``` 
/usr/bin/env: ‘python’: No such file or directory
make[2]: *** [CMakeFiles/samplespecialjointrobot_hrpsys_ros_bridge_compile_conf.dir/build.make:61: /root/hiro_ws/src/rtmros_common/hrpsys_ros_bridge/models/SampleSpecialJointRobot_controller_config.yaml] Error 127
make[1]: *** [CMakeFiles/Makefile2:20505: CMakeFiles/samplespecialjointrobot_hrpsys_ros_bridge_compile_conf.dir/all] Error 2
```

This PR fixes this error by applying a patch similar to https://github.com/tork-a/openrtm_aist_python-release/pull/5.